### PR TITLE
Update Schatzhebungstreffen: April 29.4., Mai 27.5.

### DIFF
--- a/content/events/2026/202541.md
+++ b/content/events/2026/202541.md
@@ -1,8 +1,8 @@
 +++
 title = "Schatzhebungstreffen Colearning Bern"
-event_id = 202540
-startdate = "2026-04-29T18:00:00"
-enddate = "2026-04-29T20:00:00"
+event_id = 202541
+startdate = "2026-05-27T18:00:00"
+enddate = "2026-05-27T20:00:00"
 description = "Gemeinsam essen, gemeinsam lernen – was gibt's Besseres?"
 image = "/upload/schatzhebungstreffen_tavolata.jpg"
 categories = ["Colearning"]


### PR DESCRIPTION
## Summary

- April-Termin von 23.4. auf **29.4.2026** korrigiert
- Neuer Mai-Termin **27.5.2026** hinzugefügt (gleiche Zeiten 18–20 Uhr, gleicher Text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)